### PR TITLE
Skip du warnings and monitor parts to be merged

### DIFF
--- a/src/plugins/clickhouse_database_size
+++ b/src/plugins/clickhouse_database_size
@@ -18,9 +18,9 @@ then
 
 else
 
-    DEFAULT_DATADIR="/var/lib/clickhouse/data"
+    DEFAULT_DATADIR="/localdata3/ch/data"
     DATADIR="${CLICKHOUSE_DATADIR:-$DEFAULT_DATADIR}"
     printf "size.value "
-    du -s -B1 $DATADIR | cut -f1
+    du -s -B1 $DATADIR | grep $DATADIR | cut -f1
 
 fi

--- a/src/plugins/clickhouse_max_part_count_for_partition
+++ b/src/plugins/clickhouse_max_part_count_for_partition
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+if [ "$1" = "config" ] 
+then
+
+    echo "graph_title MaxPartCountForPartition"
+    echo "graph_category clickhouse"
+    echo "graph_vlabel Max Count"
+    echo "graph_args --base 1000"
+    echo "max_part_count.label Max Count"
+    echo "max_part_count.type GAUGE"
+    echo "max_part_count.max 1000"
+    exit 0
+
+else
+
+    DEFAULT_URL="http://localhost:8123/?readonly=1"
+    URL="${CLICKHOUSE_URL:-$DEFAULT_URL}"
+    SQL="SELECT 'max_part_count.value', value FROM system.asynchronous_metrics WHERE metric = 'MaxPartCountForPartition'"
+    echo $SQL | curl -sS $URL --data-binary @-
+
+fi


### PR DESCRIPTION
When ClickHouse is merging files, du emits warnings about missing files. This filters du output so Munin does not log these expected warnings.